### PR TITLE
Pageswitch format

### DIFF
--- a/NP_ShowBlogs.php
+++ b/NP_ShowBlogs.php
@@ -100,6 +100,17 @@ class NP_ShowBlogs extends NucleusPlugin
 		$this->createOption('tagMode',       _TAG_MODE,   'select',   '2', _TAG_SELECT);
 		$this->createBlogOption('nextLabel', _SB_NEXTL,   'text',     'Next&raquo;');
 		$this->createBlogOption('prevLabel', _SB_PREVL,   'text',     '&laquo;Prev');
+		$this->createBlogOption('nextSep',   _SB_NEXTSEP, 'text',     '| ');
+		$this->createBlogOption('prevSep',   _SB_PREVSEP, 'text',     ' |');
+		$this->createBlogOption('pageSep2',  _SB_PAGESEP2,'text',     '|');
+		$this->createBlogOption('pageSep3',  _SB_PAGESEP3,'text',     '&middot;');
+		$this->createBlogOption('pgListHdr', _SB_PGLSTHDR,'text',     '');
+		$this->createBlogOption('pgListFtr', _SB_PGLSTFTR,'text',     '');
+		$this->createBlogOption('pagePrefix',_SB_PGPREFIX,'text',     ' ');
+		$this->createBlogOption('pageSuffix',_SB_PGSUFFIX,'text',     ' ');
+		$this->createBlogOption('pageDots',  _SB_PAGEDOTS,'text',     '...');
+		$this->createBlogOption('curPgPrfix',_SB_CURPGPRF,'text',     '<strong>');
+		$this->createBlogOption('curPgSffix',_SB_CURPGSUF,'text',     '</strong>');			
 /* todo can't install ? only warning ?
  * douyatte 'desc' ni keikoku wo daseba iinoka wakaranai desu
 		$ver_min = (getNucleusVersion() < $this->getMinNucleusVersion());
@@ -674,6 +685,17 @@ class NP_ShowBlogs extends NucleusPlugin
 		}
 		$nextLinkLabel = $this->getBlogOption($this->nowbid, 'nextLabel') ? $this->getBlogOption($this->nowbid, 'nextLabel') : 'Next&raquo;';
 		$prevLinkLabel = $this->getBlogOption($this->nowbid, 'prevLabel') ? $this->getBlogOption($this->nowbid, 'prevLabel') : '&laquo;Prev';
+		$nextSep = $this->getBlogOption($this->nowbid, 'nextSep') ? $this->getBlogOption($this->nowbid, 'nextSep') : '| ';
+		$prevSep = $this->getBlogOption($this->nowbid, 'PrevSep') ? $this->getBlogOption($this->nowbid, 'prevSep') : ' |';
+		$pageSep2 = $this->getBlogOption($this->nowbid, 'pageSep2') ? $this->getBlogOption($this->nowbid, 'pageSep2') : '|';
+		$pageSep3 = $this->getBlogOption($this->nowbid, 'pageSep3') ? $this->getBlogOption($this->nowbid, 'pageSep3') : '&middot;';
+		$pgListHdr = $this->getBlogOption($this->nowbid, 'pgListHdr') ? $this->getBlogOption($this->nowbid, 'pgListHdr') : '';
+		$pgListFtr = $this->getBlogOption($this->nowbid, 'pgListFtr') ? $this->getBlogOption($this->nowbid, 'pgListFtr') : '';
+		$pagePrefix = $this->getBlogOption($this->nowbid, 'pagePrefix') ? $this->getBlogOption($this->nowbid, 'pagePrefix') : ' ';
+		$pageSuffix = $this->getBlogOption($this->nowbid, 'pageSuffix') ? $this->getBlogOption($this->nowbid, 'pageSuffix') : ' ';
+		$pageDots = $this->getBlogOption($this->nowbid, 'pageDots') ? $this->getBlogOption($this->nowbid, 'pageDots') : '...';		
+		$curPgPrfix = $this->getBlogOption($this->nowbid, 'curPgPrfix') ? $this->getBlogOption($this->nowbid, 'curPgPrfix') : '<strong>';
+		$curPgSffix = $this->getBlogOption($this->nowbid, 'curPgSffix') ? $this->getBlogOption($this->nowbid, 'curPgSffix') : '</strong>';
 
 		if ($type >= 1) {
 			$buf .= '<div class="pageswitch">' . "\n";
@@ -684,76 +706,76 @@ class NP_ShowBlogs extends NucleusPlugin
 					$prevpagelink .= '.html';
 				}
 				$buf .= '<a href="' . $prevpagelink . '" title="Previous page" rel="Prev">'
-					  . '<span class="npsb_prevlink">' . $prevLinkLabel . '</span></a> |';
+					  . '<span class="npsb_prevlink">' . $prevLinkLabel . '</span></a>' . $prevSep;
 			} elseif ($type >= 2) {
-				$buf .= $prevLinkLabel . " |";
+				$buf .= $prevLinkLabel . $prevSep;
 			}
 			if (intval($type) == 1) {
 				$buf .= "\n";
 			}
 			if (intval($type) == 2) {
-				$sepstr = '&middot;';
-				$buf   .= "|";
+				$buf .= $pgListHdr . $pageSep2;
 				for ($i=1; $i<=$totalpages; $i++) {
 					$i_pagelink = $pagelink . $page_str . $i;
 					if ($page_str == 'page_') {
 						$i_pagelink .= '.html';
 					}
 					if ($i == $currentpage) {
-						$buf .= ' <strong>' . $i . '</strong> |' . "\n";
+						$buf .= $pagePrefix . $curPgPrfix . $i . $curPgSffix . $pageSuffix . $pageSep2 . "\n";
 					} elseif ($totalpages<10 || $i<4 || $i>$totalpages-3) {
-						$buf .= ' <a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
-							  . $i . '</a> |' . "\n";
+						$buf .= $pagePrefix . '<a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
+							  . $i . '</a>' . $pageSuffix . $pageSep2 . "\n";
 					} else {
 						if ($i<$currentpage-1 || $i>$currentpage+1) {
 							if (($i == 4 && ($currentpage > 5 || $currentpage == 1)) || $i == $currentpage + 2) {
 								$buf  = rtrim($buf);
-								$buf .= "...|\n";
+								$buf .= $pageDots . $pageSep2 . "\n";
 							}
 						} else {
-							$buf .= ' <a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
-								  . $i . '</a> |' . "\n";
+							$buf .= $pagePrefix . '<a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
+								  . $i . '</a>' . $pageSuffix . $pageSep2 . "\n";
 						}
 					}
 				}
-				$buf = rtrim($buf);
+				$buf = rtrim($buf) . $pgListFtr;
 			}
 			if (intval($type) == 3) {
-				$buf .= '|';
-				$sepstr = '&middot;';
-				for ($i = 1; $i <= $totalpages; $i++) {
+				$buf .= $pgListHdr . $pageSep2;
+				if ($currentpage - 4 > 1) {
+					$buf .= ' ' . $pageDots . "\n";
+				}
+				for ($i = max(1, $currentpage - 4); $i <= min($totalpages, $currentpage + 4); $i++) {
 					$i_pagelink = $pagelink . $page_str . $i;
 					if ($page_str == 'page_') {
 						$i_pagelink .= '.html';
 					}
-					$paging = 5;
 					if ($i == $currentpage) {
-						$buf .= ' <strong>' . $i . '</strong> ' . $sepstr . "\n";
-					} elseif ($totalpages < 10 || ($i < ($currentpage + $paging) && ($currentpage - $paging) < $i)) {
-						$buf .= ' <a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
-							  . $i . '</a> ' . $sepstr . "\n";
-					} elseif ($currentpage - $paging == $i) {
-						$buf = rtrim($buf);
-						$buf .= ' ...'."\n";
-					} elseif ($currentpage + $paging == $i) {
-						$buf = rtrim($buf);
-						$buf = preg_replace('/$sepstr$/', '', $buf);
-						$buf .= "... |\n";
+						$bufarray[] = $pagePrefix . $curPgPrfix . $i .  $curPgSffix . $pageSuffix . "\n";
+					} else {
+						$bufarray[] = $pagePrefix . '<a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
+							  . $i . '</a>' . $pageSuffix . "\n";
 					}
 				}
+				$buf .= implode($pageSep3, $bufarray);
+				if ($currentpage + 4 < $totalpages) {
+					$buf .= $pageDots . ' ';
+				}
+				$buf .= $pageSep2;
+				$buf .= $pgListFtr;
 			}
 			if ($totalpages >= $nextpage) {
 				$nextpagelink = $pagelink . $page_str . $nextpage;
 				if ($page_str == 'page_') {
 					$nextpagelink .= '.html';
 				}
-				$buf .= '| <a href="' . $nextpagelink . '" title="Next page" rel="Next">'
+				$buf .=  $nextSep . '<a href="' . $nextpagelink . '" title="Next page" rel="Next">'
 					  . '<span class="npsb_nextlink">' . $nextLinkLabel . '</span></a>' . "\n";
 			} elseif ($type >= 2) {
-				$buf .= "| " . $nextLinkLabel . "\n";
+				$buf .= $nextSep . $nextLinkLabel . "\n";
 			}
 //			$buf .= " | <a rel=\"last\" title=\"Last page\" href=\"{$lastpagelink}\">&lt;LAST&gt;</a>\n";
 			$buf .= "</div>\n";
+
 			return array('buf' => $buf, 'startpos' => intval($startpos));
 		}
 	}

--- a/NP_ShowBlogs.php
+++ b/NP_ShowBlogs.php
@@ -708,7 +708,7 @@ class NP_ShowBlogs extends NucleusPlugin
 				$buf .= '<a href="' . $prevpagelink . '" title="Previous page" rel="Prev">'
 					  . '<span class="npsb_prevlink">' . $prevLinkLabel . '</span></a>' . $prevSep;
 			} elseif ($type >= 2) {
-				$buf .= $prevLinkLabel . $prevSep;
+				$buf .= '<span class="npsb_prevnolink">' . $prevLinkLabel . '</span>' . $prevSep;
 			}
 			if (intval($type) == 1) {
 				$buf .= "\n";
@@ -771,7 +771,7 @@ class NP_ShowBlogs extends NucleusPlugin
 				$buf .=  $nextSep . '<a href="' . $nextpagelink . '" title="Next page" rel="Next">'
 					  . '<span class="npsb_nextlink">' . $nextLinkLabel . '</span></a>' . "\n";
 			} elseif ($type >= 2) {
-				$buf .= $nextSep . $nextLinkLabel . "\n";
+				$buf .= $nextSep . '<span class="npsb_nextnolink">' . $nextLinkLabel . "</span>\n";
 			}
 //			$buf .= " | <a rel=\"last\" title=\"Last page\" href=\"{$lastpagelink}\">&lt;LAST&gt;</a>\n";
 			$buf .= "</div>\n";

--- a/NP_ShowBlogs.php
+++ b/NP_ShowBlogs.php
@@ -100,17 +100,6 @@ class NP_ShowBlogs extends NucleusPlugin
 		$this->createOption('tagMode',       _TAG_MODE,   'select',   '2', _TAG_SELECT);
 		$this->createBlogOption('nextLabel', _SB_NEXTL,   'text',     'Next&raquo;');
 		$this->createBlogOption('prevLabel', _SB_PREVL,   'text',     '&laquo;Prev');
-		$this->createBlogOption('nextSep',   _SB_NEXTSEP, 'text',     '| ');
-		$this->createBlogOption('prevSep',   _SB_PREVSEP, 'text',     ' |');
-		$this->createBlogOption('pageSep2',  _SB_PAGESEP2,'text',     '|');
-		$this->createBlogOption('pageSep3',  _SB_PAGESEP3,'text',     '&middot;');
-		$this->createBlogOption('pgListHdr', _SB_PGLSTHDR,'text',     '');
-		$this->createBlogOption('pgListFtr', _SB_PGLSTFTR,'text',     '');
-		$this->createBlogOption('pagePrefix',_SB_PGPREFIX,'text',     ' ');
-		$this->createBlogOption('pageSuffix',_SB_PGSUFFIX,'text',     ' ');
-		$this->createBlogOption('pageDots',  _SB_PAGEDOTS,'text',     '...');
-		$this->createBlogOption('curPgPrfix',_SB_CURPGPRF,'text',     '<strong>');
-		$this->createBlogOption('curPgSffix',_SB_CURPGSUF,'text',     '</strong>');			
 /* todo can't install ? only warning ?
  * douyatte 'desc' ni keikoku wo daseba iinoka wakaranai desu
 		$ver_min = (getNucleusVersion() < $this->getMinNucleusVersion());
@@ -685,17 +674,6 @@ class NP_ShowBlogs extends NucleusPlugin
 		}
 		$nextLinkLabel = $this->getBlogOption($this->nowbid, 'nextLabel') ? $this->getBlogOption($this->nowbid, 'nextLabel') : 'Next&raquo;';
 		$prevLinkLabel = $this->getBlogOption($this->nowbid, 'prevLabel') ? $this->getBlogOption($this->nowbid, 'prevLabel') : '&laquo;Prev';
-		$nextSep = $this->getBlogOption($this->nowbid, 'nextSep') ? $this->getBlogOption($this->nowbid, 'nextSep') : '| ';
-		$prevSep = $this->getBlogOption($this->nowbid, 'PrevSep') ? $this->getBlogOption($this->nowbid, 'prevSep') : ' |';
-		$pageSep2 = $this->getBlogOption($this->nowbid, 'pageSep2') ? $this->getBlogOption($this->nowbid, 'pageSep2') : '|';
-		$pageSep3 = $this->getBlogOption($this->nowbid, 'pageSep3') ? $this->getBlogOption($this->nowbid, 'pageSep3') : '&middot;';
-		$pgListHdr = $this->getBlogOption($this->nowbid, 'pgListHdr') ? $this->getBlogOption($this->nowbid, 'pgListHdr') : '';
-		$pgListFtr = $this->getBlogOption($this->nowbid, 'pgListFtr') ? $this->getBlogOption($this->nowbid, 'pgListFtr') : '';
-		$pagePrefix = $this->getBlogOption($this->nowbid, 'pagePrefix') ? $this->getBlogOption($this->nowbid, 'pagePrefix') : ' ';
-		$pageSuffix = $this->getBlogOption($this->nowbid, 'pageSuffix') ? $this->getBlogOption($this->nowbid, 'pageSuffix') : ' ';
-		$pageDots = $this->getBlogOption($this->nowbid, 'pageDots') ? $this->getBlogOption($this->nowbid, 'pageDots') : '...';		
-		$curPgPrfix = $this->getBlogOption($this->nowbid, 'curPgPrfix') ? $this->getBlogOption($this->nowbid, 'curPgPrfix') : '<strong>';
-		$curPgSffix = $this->getBlogOption($this->nowbid, 'curPgSffix') ? $this->getBlogOption($this->nowbid, 'curPgSffix') : '</strong>';
 
 		if ($type >= 1) {
 			$buf .= '<div class="pageswitch">' . "\n";
@@ -706,76 +684,76 @@ class NP_ShowBlogs extends NucleusPlugin
 					$prevpagelink .= '.html';
 				}
 				$buf .= '<a href="' . $prevpagelink . '" title="Previous page" rel="Prev">'
-					  . '<span class="npsb_prevlink">' . $prevLinkLabel . '</span></a>' . $prevSep;
+					  . '<span class="npsb_prevlink">' . $prevLinkLabel . '</span></a> |';
 			} elseif ($type >= 2) {
-				$buf .= $prevLinkLabel . $prevSep;
+				$buf .= $prevLinkLabel . " |";
 			}
 			if (intval($type) == 1) {
 				$buf .= "\n";
 			}
 			if (intval($type) == 2) {
-				$buf .= $pgListHdr . $pageSep2;
+				$sepstr = '&middot;';
+				$buf   .= "|";
 				for ($i=1; $i<=$totalpages; $i++) {
 					$i_pagelink = $pagelink . $page_str . $i;
 					if ($page_str == 'page_') {
 						$i_pagelink .= '.html';
 					}
 					if ($i == $currentpage) {
-						$buf .= $pagePrefix . $curPgPrfix . $i . $curPgSffix . $pageSuffix . $pageSep2 . "\n";
+						$buf .= ' <strong>' . $i . '</strong> |' . "\n";
 					} elseif ($totalpages<10 || $i<4 || $i>$totalpages-3) {
-						$buf .= $pagePrefix . '<a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
-							  . $i . '</a>' . $pageSuffix . $pageSep2 . "\n";
+						$buf .= ' <a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
+							  . $i . '</a> |' . "\n";
 					} else {
 						if ($i<$currentpage-1 || $i>$currentpage+1) {
 							if (($i == 4 && ($currentpage > 5 || $currentpage == 1)) || $i == $currentpage + 2) {
 								$buf  = rtrim($buf);
-								$buf .= $pageDots . $pageSep2 . "\n";
+								$buf .= "...|\n";
 							}
 						} else {
-							$buf .= $pagePrefix . '<a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
-								  . $i . '</a>' . $pageSuffix . $pageSep2 . "\n";
+							$buf .= ' <a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
+								  . $i . '</a> |' . "\n";
 						}
 					}
 				}
-				$buf = rtrim($buf) . $pgListFtr;
+				$buf = rtrim($buf);
 			}
 			if (intval($type) == 3) {
-				$buf .= $pgListHdr . $pageSep2;
-				if ($currentpage - 4 > 1) {
-					$buf .= ' ' . $pageDots . "\n";
-				}
-				for ($i = max(1, $currentpage - 4); $i <= min($totalpages, $currentpage + 4); $i++) {
+				$buf .= '|';
+				$sepstr = '&middot;';
+				for ($i = 1; $i <= $totalpages; $i++) {
 					$i_pagelink = $pagelink . $page_str . $i;
 					if ($page_str == 'page_') {
 						$i_pagelink .= '.html';
 					}
+					$paging = 5;
 					if ($i == $currentpage) {
-						$bufarray[] = $pagePrefix . $curPgPrfix . $i .  $curPgSffix . $pageSuffix . "\n";
-					} else {
-						$bufarray[] = $pagePrefix . '<a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
-							  . $i . '</a>' . $pageSuffix . "\n";
+						$buf .= ' <strong>' . $i . '</strong> ' . $sepstr . "\n";
+					} elseif ($totalpages < 10 || ($i < ($currentpage + $paging) && ($currentpage - $paging) < $i)) {
+						$buf .= ' <a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
+							  . $i . '</a> ' . $sepstr . "\n";
+					} elseif ($currentpage - $paging == $i) {
+						$buf = rtrim($buf);
+						$buf .= ' ...'."\n";
+					} elseif ($currentpage + $paging == $i) {
+						$buf = rtrim($buf);
+						$buf = preg_replace('/$sepstr$/', '', $buf);
+						$buf .= "... |\n";
 					}
 				}
-				$buf .= implode($pageSep3, $bufarray);
-				if ($currentpage + 4 < $totalpages) {
-					$buf .= $pageDots . ' ';
-				}
-				$buf .= $pageSep2;
-				$buf .= $pgListFtr;
 			}
 			if ($totalpages >= $nextpage) {
 				$nextpagelink = $pagelink . $page_str . $nextpage;
 				if ($page_str == 'page_') {
 					$nextpagelink .= '.html';
 				}
-				$buf .=  $nextSep . '<a href="' . $nextpagelink . '" title="Next page" rel="Next">'
+				$buf .= '| <a href="' . $nextpagelink . '" title="Next page" rel="Next">'
 					  . '<span class="npsb_nextlink">' . $nextLinkLabel . '</span></a>' . "\n";
 			} elseif ($type >= 2) {
-				$buf .= $nextSep . $nextLinkLabel . "\n";
+				$buf .= "| " . $nextLinkLabel . "\n";
 			}
 //			$buf .= " | <a rel=\"last\" title=\"Last page\" href=\"{$lastpagelink}\">&lt;LAST&gt;</a>\n";
 			$buf .= "</div>\n";
-
 			return array('buf' => $buf, 'startpos' => intval($startpos));
 		}
 	}

--- a/NP_ShowBlogs.php
+++ b/NP_ShowBlogs.php
@@ -685,17 +685,17 @@ class NP_ShowBlogs extends NucleusPlugin
 		}
 		$nextLinkLabel = $this->getBlogOption($this->nowbid, 'nextLabel') ? $this->getBlogOption($this->nowbid, 'nextLabel') : 'Next&raquo;';
 		$prevLinkLabel = $this->getBlogOption($this->nowbid, 'prevLabel') ? $this->getBlogOption($this->nowbid, 'prevLabel') : '&laquo;Prev';
-		$nextSep = $this->getBlogOption($this->nowbid, 'nextSep') ? $this->getBlogOption($this->nowbid, 'nextSep') : '| ';
-		$prevSep = $this->getBlogOption($this->nowbid, 'PrevSep') ? $this->getBlogOption($this->nowbid, 'prevSep') : ' |';
-		$pageSep2 = $this->getBlogOption($this->nowbid, 'pageSep2') ? $this->getBlogOption($this->nowbid, 'pageSep2') : '|';
-		$pageSep3 = $this->getBlogOption($this->nowbid, 'pageSep3') ? $this->getBlogOption($this->nowbid, 'pageSep3') : '&middot;';
-		$pgListHdr = $this->getBlogOption($this->nowbid, 'pgListHdr') ? $this->getBlogOption($this->nowbid, 'pgListHdr') : '';
-		$pgListFtr = $this->getBlogOption($this->nowbid, 'pgListFtr') ? $this->getBlogOption($this->nowbid, 'pgListFtr') : '';
-		$pagePrefix = $this->getBlogOption($this->nowbid, 'pagePrefix') ? $this->getBlogOption($this->nowbid, 'pagePrefix') : ' ';
-		$pageSuffix = $this->getBlogOption($this->nowbid, 'pageSuffix') ? $this->getBlogOption($this->nowbid, 'pageSuffix') : ' ';
+		$nextSep = $this->getBlogOption($this->nowbid, 'nextSep');
+		$prevSep = $this->getBlogOption($this->nowbid, 'PrevSep');
+		$pageSep2 = $this->getBlogOption($this->nowbid, 'pageSep2');
+		$pageSep3 = $this->getBlogOption($this->nowbid, 'pageSep3');
+		$pgListHdr = $this->getBlogOption($this->nowbid, 'pgListHdr');
+		$pgListFtr = $this->getBlogOption($this->nowbid, 'pgListFtr');
+		$pagePrefix = $this->getBlogOption($this->nowbid, 'pagePrefix');
+		$pageSuffix = $this->getBlogOption($this->nowbid, 'pageSuffix');
 		$pageDots = $this->getBlogOption($this->nowbid, 'pageDots') ? $this->getBlogOption($this->nowbid, 'pageDots') : '...';		
-		$curPgPrfix = $this->getBlogOption($this->nowbid, 'curPgPrfix') ? $this->getBlogOption($this->nowbid, 'curPgPrfix') : '<strong>';
-		$curPgSffix = $this->getBlogOption($this->nowbid, 'curPgSffix') ? $this->getBlogOption($this->nowbid, 'curPgSffix') : '</strong>';
+		$curPgPrfix = $this->getBlogOption($this->nowbid, 'curPgPrfix');
+		$curPgSffix = $this->getBlogOption($this->nowbid, 'curPgSffix');
 
 		if ($type >= 1) {
 			$buf .= '<div class="pageswitch">' . "\n";
@@ -721,7 +721,7 @@ class NP_ShowBlogs extends NucleusPlugin
 						$i_pagelink .= '.html';
 					}
 					if ($i == $currentpage) {
-						$buf .= $pagePrefix . $curPgPrfix . $i . $curPgSffix . $pageSuffix . $pageSep2 . "\n";
+						$buf .= $curPgPrfix . $i . $curPgSffix . $pageSep2 . "\n";
 					} elseif ($totalpages<10 || $i<4 || $i>$totalpages-3) {
 						$buf .= $pagePrefix . '<a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
 							  . $i . '</a>' . $pageSuffix . $pageSep2 . "\n";
@@ -750,7 +750,7 @@ class NP_ShowBlogs extends NucleusPlugin
 						$i_pagelink .= '.html';
 					}
 					if ($i == $currentpage) {
-						$bufarray[] = $pagePrefix . $curPgPrfix . $i .  $curPgSffix . $pageSuffix . "\n";
+						$bufarray[] = $curPgPrfix . $i . $curPgSffix . "\n";
 					} else {
 						$bufarray[] = $pagePrefix . '<a href="' . $i_pagelink . '" title="Page No.' . $i . '">'
 							  . $i . '</a>' . $pageSuffix . "\n";

--- a/showblogs/english.php
+++ b/showblogs/english.php
@@ -11,17 +11,6 @@
 	define('_TAG_MODE',     'TagEX narrow mode on page-switch');
 	define('_SB_NEXTL',     'Link text for NextPage');
 	define('_SB_PREVL',     'Link text for PrevPage');
-	define('_SB_NEXTSEP',   'Separator text before the NextPage link');
-	define('_SB_PREVSEP',   'Separator text after the PrevPage link');
-	define('_SB_PAGESEP2',  'Separator text between the pages for Type 2 page switch');
-	define('_SB_PAGESEP3',  'Separator text between the pages for Type 3 page switch');
-	define('_SB_PGLSTHDR',  'Header text before the page link list');
-	define('_SB_PGLSTFTR',  'Footer text after the page link list');
-	define('_SB_PGPREFIX',  'Prefix text before each page link');
-	define('_SB_PGSUFFIX',  'Suffix text after each page link');
-	define('_SB_PAGEDOTS',  'Text for pagination dots');
-	define('_SB_CURPGPRF',  'Prefix text before current page number');
-	define('_SB_CURPGSUF',  'Suffix text after current page number');
 	define('_TAG_SELECT',   'all blogs|0|currentblog only|1|narrowed with catid/subcatid|2');
 	define('_STICKSELECT',  'show all stickyID|0|show current blog stickyID only|1');
 ?>

--- a/showblogs/english.php
+++ b/showblogs/english.php
@@ -11,6 +11,17 @@
 	define('_TAG_MODE',     'TagEX narrow mode on page-switch');
 	define('_SB_NEXTL',     'Link text for NextPage');
 	define('_SB_PREVL',     'Link text for PrevPage');
+	define('_SB_NEXTSEP',   'Separator text before the NextPage link');
+	define('_SB_PREVSEP',   'Separator text after the PrevPage link');
+	define('_SB_PAGESEP2',  'Separator text between the pages for Type 2 page switch');
+	define('_SB_PAGESEP3',  'Separator text between the pages for Type 3 page switch');
+	define('_SB_PGLSTHDR',  'Header text before the page link list');
+	define('_SB_PGLSTFTR',  'Footer text after the page link list');
+	define('_SB_PGPREFIX',  'Prefix text before each page link');
+	define('_SB_PGSUFFIX',  'Suffix text after each page link');
+	define('_SB_PAGEDOTS',  'Text for pagination dots');
+	define('_SB_CURPGPRF',  'Prefix text before current page number');
+	define('_SB_CURPGSUF',  'Suffix text after current page number');
 	define('_TAG_SELECT',   'all blogs|0|currentblog only|1|narrowed with catid/subcatid|2');
 	define('_STICKSELECT',  'show all stickyID|0|show current blog stickyID only|1');
 ?>

--- a/showblogs/japanese-utf8.php
+++ b/showblogs/japanese-utf8.php
@@ -14,17 +14,6 @@
 	define('_TAG_MODE',     'NP_TagEX 使用時のページスイッチのモード');
 	define('_SB_NEXTL',     '次のページへのリンクテキスト');
 	define('_SB_PREVL',     '前のページへのリンクテキスト');
-	define('_SB_NEXTSEP',   '次のページへのリンクテキストの前に表示するセパレータ');
-	define('_SB_PREVSEP',   '前のページへのリンクテキストの後に表示するセパレータ');
-	define('_SB_PAGESEP2',  'タイプ2のページスイッチのページ同士の間に表示するセパレータ');
-	define('_SB_PAGESEP3',  'タイプ3のページスイッチのページ同士の間に表示するセパレータ');
-	define('_SB_PGLSTHDR',  'ページへのリンクのリストの前に表示するヘッダ');
-	define('_SB_PGLSTFTR',  'ページへのリンクのリストの後に表示するフッタ');
-	define('_SB_PGPREFIX',  '各ページへのリンクの前に付加するプリフィックス');
-	define('_SB_PGSUFFIX',  '各ページへのリンクの後に付加するサフィックス');
-	define('_SB_PAGEDOTS',  'ページスイッチでページを省略表示するテキスト');
-	define('_SB_CURPGPRF',  '現在表示中のページ番号の前に付加するプリフィックス');
-	define('_SB_CURPGSUF',  '現在表示中のページ番号の後に付加するサフィックス');		
 	define('_TAG_SELECT',   '全ブログの tag を表示|0|'
 						  . '表示中のブログに属する tag のみ表示|1|'
 						  . '表示中のカテゴリ・サブカテゴリに属する tag のみ表示|2');

--- a/showblogs/japanese-utf8.php
+++ b/showblogs/japanese-utf8.php
@@ -14,6 +14,17 @@
 	define('_TAG_MODE',     'NP_TagEX 使用時のページスイッチのモード');
 	define('_SB_NEXTL',     '次のページへのリンクテキスト');
 	define('_SB_PREVL',     '前のページへのリンクテキスト');
+	define('_SB_NEXTSEP',   '次のページへのリンクテキストの前に表示するセパレータ');
+	define('_SB_PREVSEP',   '前のページへのリンクテキストの後に表示するセパレータ');
+	define('_SB_PAGESEP2',  'タイプ2のページスイッチのページ同士の間に表示するセパレータ');
+	define('_SB_PAGESEP3',  'タイプ3のページスイッチのページ同士の間に表示するセパレータ');
+	define('_SB_PGLSTHDR',  'ページへのリンクのリストの前に表示するヘッダ');
+	define('_SB_PGLSTFTR',  'ページへのリンクのリストの後に表示するフッタ');
+	define('_SB_PGPREFIX',  '各ページへのリンクの前に付加するプリフィックス');
+	define('_SB_PGSUFFIX',  '各ページへのリンクの後に付加するサフィックス');
+	define('_SB_PAGEDOTS',  'ページスイッチでページを省略表示するテキスト');
+	define('_SB_CURPGPRF',  '現在表示中のページ番号の前に付加するプリフィックス');
+	define('_SB_CURPGSUF',  '現在表示中のページ番号の後に付加するサフィックス');		
 	define('_TAG_SELECT',   '全ブログの tag を表示|0|'
 						  . '表示中のブログに属する tag のみ表示|1|'
 						  . '表示中のカテゴリ・サブカテゴリに属する tag のみ表示|2');


### PR DESCRIPTION
ページスイッチの表示デザインをCSSでいじりやすいように、ページスイッチで使う表示フォーマットをブログ設定のオプションで書き換えられるように変更しました。
後方互換性ありなので、バージョンアップしても表示はくずれません。

Formatting text in the page switch carousel is now configurable in Blog setting options so that user can modify the format, which makes altering design using CSS.
Backward compatible with older versions.
